### PR TITLE
security: remediate CVEs in MCP SDK and Hono

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,15 +9,15 @@
       "version": "1.0.0",
       "dependencies": {
         "@cloudflare/workers-oauth-provider": "^0.3.0",
-        "@modelcontextprotocol/sdk": "^1.26.0",
+        "@modelcontextprotocol/sdk": "^1.27.1",
         "agents": "^0.7.9",
-        "hono": "^4.12.7",
+        "hono": "^4.12.9",
         "zod": "^3.24.4"
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "^4.20250312.0",
+        "@cloudflare/workers-types": "^4.20260317.1",
         "typescript": "^5.8.3",
-        "wrangler": "^4.14.4"
+        "wrangler": "^4.77.0"
       }
     },
     "node_modules/@ai-sdk/gateway": {
@@ -124,9 +124,9 @@
       }
     },
     "node_modules/@cloudflare/unenv-preset": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.15.0.tgz",
-      "integrity": "sha512-EGYmJaGZKWl+X8tXxcnx4v2bOZSjQeNI5dWFeXivgX9+YCT69AkzHHwlNbVpqtEUTbew8eQurpyOpeN8fg00nw==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.0.tgz",
+      "integrity": "sha512-8ovsRpwzPoEqPUzoErAYVv8l3FMZNeBVQfJTvtzP4AgLSRGZISRfuChFxHWUQd3n6cnrwkuTGxT+2cGo8EsyYg==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "peerDependencies": {
@@ -250,9 +250,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.0.tgz",
-      "integrity": "sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
+      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1239,9 +1239,9 @@
       "license": "MIT"
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
-      "integrity": "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==",
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
+      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.9",
@@ -2154,9 +2154,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.8",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.8.tgz",
-      "integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==",
+      "version": "4.12.9",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.9.tgz",
+      "integrity": "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -2432,9 +2432,9 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "4.20260317.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260317.0.tgz",
-      "integrity": "sha512-xuwk5Kjv+shi5iUBAdCrRl9IaWSGnTU8WuTQzsUS2GlSDIMCJuu8DiF/d9ExjMXYiQG5ml+k9SVKnMj8cRkq0w==",
+      "version": "4.20260317.2",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260317.2.tgz",
+      "integrity": "sha512-qNL+yWAFMX6fr0pWU6Lx1vNpPobpnDSF1V8eunIckWvoIQl8y1oBjL2RJFEGY3un+l3f9gwW9dirDPP26usYJQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3121,17 +3121,17 @@
       }
     },
     "node_modules/wrangler": {
-      "version": "4.75.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.75.0.tgz",
-      "integrity": "sha512-Efk1tcnm4eduBYpH1sSjMYydXMnIFPns/qABI3+fsbDrUk5GksNYX8nYGVP4sFygvGPO7kJc36YJKB5ooA7JAg==",
+      "version": "4.77.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.77.0.tgz",
+      "integrity": "sha512-E2Gm69+K++BFd3QvoWjC290RPQj1vDOUotA++sNHmtKPb7EP6C8Qv+1D5Ii73tfZtyNgakpqHlh8lBBbVWTKAQ==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@cloudflare/kv-asset-handler": "0.4.2",
-        "@cloudflare/unenv-preset": "2.15.0",
+        "@cloudflare/unenv-preset": "2.16.0",
         "blake3-wasm": "2.1.5",
         "esbuild": "0.27.3",
-        "miniflare": "4.20260317.0",
+        "miniflare": "4.20260317.2",
         "path-to-regexp": "6.3.0",
         "unenv": "2.0.0-rc.24",
         "workerd": "1.20260317.1"
@@ -3141,7 +3141,7 @@
         "wrangler2": "bin/wrangler.js"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=20.3.0"
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"

--- a/package.json
+++ b/package.json
@@ -12,14 +12,17 @@
   },
   "dependencies": {
     "@cloudflare/workers-oauth-provider": "^0.3.0",
-    "@modelcontextprotocol/sdk": "^1.26.0",
+    "@modelcontextprotocol/sdk": "^1.27.1",
     "agents": "^0.7.9",
-    "hono": "^4.12.7",
+    "hono": "^4.12.9",
     "zod": "^3.24.4"
   },
+  "overrides": {
+    "@modelcontextprotocol/sdk": "$@modelcontextprotocol/sdk"
+  },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20250312.0",
+    "@cloudflare/workers-types": "^4.20260317.1",
     "typescript": "^5.8.3",
-    "wrangler": "^4.14.4"
+    "wrangler": "^4.77.0"
   }
 }


### PR DESCRIPTION
## Summary

- **@modelcontextprotocol/sdk** 1.26.0 → 1.27.1 — fixes CVE-2026-25536 (cross-client data leak), CVE-2026-0621 (ReDoS), CVE-2025-66414 (DNS rebinding)
- **hono** 4.12.8 → 4.12.9 — fixes CVE-2026-29045 (file access bypass), CVE-2026-29085 (SSE injection), CVE-2026-29086 (cookie injection), CVE-2026-24771 (XSS)
- **wrangler** 4.75.0 → 4.77.0
- Added npm `overrides` to deduplicate `@modelcontextprotocol/sdk` across the `agents` dependency tree
- **@cloudflare/workers-oauth-provider** already at 0.3.0 (above minimum secure version 0.0.5 for CVE-2025-4143, CVE-2025-4144)

## Analysis

- McpServer instantiation is per-Durable-Object instance (already safe for CVE-2026-25536, no refactor needed)
- No SSE/writeSSE usage found (CVE-2026-29085 mitigated at library level)
- `npm audit` reports 0 vulnerabilities
- TypeScript compilation passes clean

## Test plan

- [x] `npm audit` — 0 vulnerabilities
- [x] `npm run build` — TypeScript compilation passes
- [ ] Deploy to Cloudflare (requires `CLOUDFLARE_API_TOKEN` — not available in CI env)
- [ ] Verify Worker health endpoint returns 200
- [ ] Smoke test OAuth flow end-to-end

https://claude.ai/code/session_015zoPH6URbHkiD8RFKhmYYD