### PR TITLE
chore: bump wrangler compat date to 2026-04-07, add global_fetch_stri…

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,7 +1,7 @@
 name = "nit-mcp-hudu"
 main = "src/index.ts"
-compatibility_date = "2025-04-01"
-compatibility_flags = ["nodejs_compat"]
+compatibility_date = "2026-04-07"
+compatibility_flags = ["nodejs_compat", "global_fetch_strictly_public"]
 account_id = "7ac71ffa8a171e8755646124094cb9f3"
 
 [vars]


### PR DESCRIPTION
…ctly_public

- compatibility_date 2025-04-01 → 2026-04-07 (picks up ~12 months of Workers runtime improvements including process v2 for better Node.js compatibility)
- compatibility_flags add global_fetch_strictly_public, which tightens outbound-fetch safety for our calls to docs.networkzit.com (Hudu), login.microsoftonline.com (Entra token endpoint), and graph.microsoft.com (/me lookup). Also resolves the CIMD warning Cloudflare was logging on every boot.

Matches the compat date already running on the sibling HaloPSA connector, which has been stable since April 2026.

Verified: wrangler deploy --dry-run on 4.84.1 accepts the config; bundle size dropped 1026 → 959 KiB as runtime features moved into the platform.