### PR TITLE
chore(observability): drop per-request logs, log err.message not err.…

### DIFF
--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -39,8 +39,6 @@ export async function huduFetch<T>(
     }
   }
 
-  console.log(`[huduFetch] GET ${endpoint} page=${url.searchParams.get("page") ?? "-"}`);
-
   const response = await fetch(url.toString(), {
     headers: {
       "x-api-key": env.HUDU_API_KEY,
@@ -49,7 +47,6 @@ export async function huduFetch<T>(
   });
 
   const text = await response.text();
-  console.log(`[huduFetch] ${endpoint} -> ${response.status}`);
 
   if (response.status === 429) {
     throw new Error(
@@ -84,8 +81,6 @@ export async function huduMutate<T>(
 
   const url = new URL(`${env.HUDU_BASE_URL}/${endpoint}`);
 
-  console.log(`[huduMutate] ${method} ${endpoint}`);
-
   const response = await fetch(url.toString(), {
     method,
     headers: {
@@ -96,7 +91,6 @@ export async function huduMutate<T>(
   });
 
   const text = await response.text();
-  console.log(`[huduMutate] ${endpoint} -> ${response.status}`);
 
   if (response.status === 429) {
     throw new Error(

--- a/src/tools/activity-logs.ts
+++ b/src/tools/activity-logs.ts
@@ -38,7 +38,7 @@ export function register(server: McpServer, env: Env) {
           content: [{ type: "text" as const, text: formatActivityLogList(data) }],
         };
       } catch (err) {
-        console.error("[hudu_list_activity_logs]", err instanceof Error ? err.stack : err);
+        console.error("[hudu_list_activity_logs]", err instanceof Error ? err.message : String(err));
         throw err;
       }
     }

--- a/src/tools/articles.ts
+++ b/src/tools/articles.ts
@@ -38,7 +38,7 @@ export function register(server: McpServer, env: Env) {
           content: [{ type: "text" as const, text: formatArticleList(data) }],
         };
       } catch (err) {
-        console.error("[hudu_list_articles]", err instanceof Error ? err.stack : err);
+        console.error("[hudu_list_articles]", err instanceof Error ? err.message : String(err));
         throw err;
       }
     }
@@ -68,7 +68,7 @@ export function register(server: McpServer, env: Env) {
           content: [{ type: "text" as const, text: formatArticleDetail(article) }],
         };
       } catch (err) {
-        console.error("[hudu_get_article]", err instanceof Error ? err.stack : err);
+        console.error("[hudu_get_article]", err instanceof Error ? err.message : String(err));
         throw err;
       }
     }

--- a/src/tools/asset-layouts.ts
+++ b/src/tools/asset-layouts.ts
@@ -35,7 +35,7 @@ export function register(server: McpServer, env: Env) {
           content: [{ type: "text" as const, text: formatAssetLayoutList(data) }],
         };
       } catch (err) {
-        console.error("[hudu_list_asset_layouts]", err instanceof Error ? err.stack : err);
+        console.error("[hudu_list_asset_layouts]", err instanceof Error ? err.message : String(err));
         throw err;
       }
     }
@@ -65,7 +65,7 @@ export function register(server: McpServer, env: Env) {
           content: [{ type: "text" as const, text: formatAssetLayoutDetail(layout) }],
         };
       } catch (err) {
-        console.error("[hudu_get_asset_layout]", err instanceof Error ? err.stack : err);
+        console.error("[hudu_get_asset_layout]", err instanceof Error ? err.message : String(err));
         throw err;
       }
     }

--- a/src/tools/assets.ts
+++ b/src/tools/assets.ts
@@ -53,7 +53,7 @@ export function register(server: McpServer, env: Env) {
           content: [{ type: "text" as const, text: formatAssetList(data) }],
         };
       } catch (err) {
-        console.error("[hudu_list_assets]", err instanceof Error ? err.stack : err);
+        console.error("[hudu_list_assets]", err instanceof Error ? err.message : String(err));
         throw err;
       }
     }
@@ -83,7 +83,7 @@ export function register(server: McpServer, env: Env) {
           content: [{ type: "text" as const, text: formatAssetDetail(asset) }],
         };
       } catch (err) {
-        console.error("[hudu_get_asset]", err instanceof Error ? err.stack : err);
+        console.error("[hudu_get_asset]", err instanceof Error ? err.message : String(err));
         throw err;
       }
     }

--- a/src/tools/companies.ts
+++ b/src/tools/companies.ts
@@ -42,7 +42,7 @@ export function register(server: McpServer, env: Env) {
           content: [{ type: "text" as const, text: formatCompanyList(data) }],
         };
       } catch (err) {
-        console.error("[hudu_list_companies]", err instanceof Error ? err.stack : err);
+        console.error("[hudu_list_companies]", err instanceof Error ? err.message : String(err));
         throw err;
       }
     }
@@ -72,7 +72,7 @@ export function register(server: McpServer, env: Env) {
           content: [{ type: "text" as const, text: formatCompanyDetail(company) }],
         };
       } catch (err) {
-        console.error("[hudu_get_company]", err instanceof Error ? err.stack : err);
+        console.error("[hudu_get_company]", err instanceof Error ? err.message : String(err));
         throw err;
       }
     }

--- a/src/tools/expirations.ts
+++ b/src/tools/expirations.ts
@@ -37,7 +37,7 @@ export function register(server: McpServer, env: Env) {
           content: [{ type: "text" as const, text: formatExpirationList(data) }],
         };
       } catch (err) {
-        console.error("[hudu_list_expirations]", err instanceof Error ? err.stack : err);
+        console.error("[hudu_list_expirations]", err instanceof Error ? err.message : String(err));
         throw err;
       }
     }

--- a/src/tools/folders.ts
+++ b/src/tools/folders.ts
@@ -34,7 +34,7 @@ export function register(server: McpServer, env: Env) {
           content: [{ type: "text" as const, text: formatFolderList(data) }],
         };
       } catch (err) {
-        console.error("[hudu_list_folders]", err instanceof Error ? err.stack : err);
+        console.error("[hudu_list_folders]", err instanceof Error ? err.message : String(err));
         throw err;
       }
     }

--- a/src/tools/procedures.ts
+++ b/src/tools/procedures.ts
@@ -37,7 +37,7 @@ export function register(server: McpServer, env: Env) {
           content: [{ type: "text" as const, text: formatProcedureList(data) }],
         };
       } catch (err) {
-        console.error("[hudu_list_procedures]", err instanceof Error ? err.stack : err);
+        console.error("[hudu_list_procedures]", err instanceof Error ? err.message : String(err));
         throw err;
       }
     }
@@ -67,7 +67,7 @@ export function register(server: McpServer, env: Env) {
           content: [{ type: "text" as const, text: formatProcedureDetail(procedure) }],
         };
       } catch (err) {
-        console.error("[hudu_get_procedure]", err instanceof Error ? err.stack : err);
+        console.error("[hudu_get_procedure]", err instanceof Error ? err.message : String(err));
         throw err;
       }
     }

--- a/src/tools/relations.ts
+++ b/src/tools/relations.ts
@@ -30,7 +30,7 @@ export function register(server: McpServer, env: Env) {
           content: [{ type: "text" as const, text: formatRelationList(data) }],
         };
       } catch (err) {
-        console.error("[hudu_list_relations]", err instanceof Error ? err.stack : err);
+        console.error("[hudu_list_relations]", err instanceof Error ? err.message : String(err));
         throw err;
       }
     }

--- a/src/tools/users-groups.ts
+++ b/src/tools/users-groups.ts
@@ -30,7 +30,7 @@ export function register(server: McpServer, env: Env) {
           content: [{ type: "text" as const, text: formatUserList(data) }],
         };
       } catch (err) {
-        console.error("[hudu_list_users]", err instanceof Error ? err.stack : err);
+        console.error("[hudu_list_users]", err instanceof Error ? err.message : String(err));
         throw err;
       }
     }
@@ -61,7 +61,7 @@ export function register(server: McpServer, env: Env) {
           content: [{ type: "text" as const, text: formatGroupList(data) }],
         };
       } catch (err) {
-        console.error("[hudu_list_groups]", err instanceof Error ? err.stack : err);
+        console.error("[hudu_list_groups]", err instanceof Error ? err.message : String(err));
         throw err;
       }
     }

--- a/src/tools/websites.ts
+++ b/src/tools/websites.ts
@@ -36,7 +36,7 @@ export function register(server: McpServer, env: Env) {
           content: [{ type: "text" as const, text: formatWebsiteList(data) }],
         };
       } catch (err) {
-        console.error("[hudu_list_websites]", err instanceof Error ? err.stack : err);
+        console.error("[hudu_list_websites]", err instanceof Error ? err.message : String(err));
         throw err;
       }
     }
@@ -66,7 +66,7 @@ export function register(server: McpServer, env: Env) {
           content: [{ type: "text" as const, text: formatWebsiteDetail(website) }],
         };
       } catch (err) {
-        console.error("[hudu_get_website]", err instanceof Error ? err.stack : err);
+        console.error("[hudu_get_website]", err instanceof Error ? err.message : String(err));
         throw err;
       }
     }


### PR DESCRIPTION
…stack

Two changes, both reducing Grafana log volume without losing signal:

1. src/api-client.ts: remove the four per-request console.log calls in huduFetch and huduMutate. They fired on every Hudu API call and inflated Grafana log volume without adding actionable signal — the on-error console.error calls (which remain) are what we actually need when something goes wrong.

2. src/tools/*.ts (11 files, 18 call sites): change err instanceof Error ? err.stack : err to err instanceof Error ? err.message : String(err) Stack traces aren't actionable in a Workers environment (minified, no source maps in prod) and they leak internal file paths and module names into Grafana. err.message keeps the operational signal without the noise.

Matches the pattern already shipped on the sibling HaloPSA connector.

Verified:
- npm run typecheck clean
- npm run build clean