### PR TITLE
ci: add verify gate (typecheck + build + npm audit) before deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,15 +3,39 @@ name: Deploy to Cloudflare Workers
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
   workflow_dispatch:
 
 jobs:
-  deploy:
+  verify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "22"
+
+      - run: npm ci
+
+      - name: Type check
+        run: npm run typecheck
+
+      - name: Build
+        run: npm run build
+
+      - name: Security audit (moderate and above)
+        run: npm audit --audit-level=moderate
+
+  deploy:
+    needs: verify
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
         with:
           node-version: "22"
 


### PR DESCRIPTION
Before this change, pushes to main went straight to wrangler deploy with no pre-flight checks — broken TypeScript, failed builds, or new CVEs could silently ship.

Now every push AND every pull request runs:

  verify:
    - npm ci
    - npm run typecheck
    - npm run build
    - npm audit --audit-level=moderate

Deploy is now gated on verify passing (`needs: verify`) AND only runs on non-PR events targeting main (so PR verifies don't trigger a deploy). workflow_dispatch is preserved for manual redeploys from main.

Also bumps actions/checkout@v4 → @v5 and setup-node@v4 → @v5 to match the sibling HaloPSA connector's pinned versions.

Behaviour change summary:
- PRs targeting main: new verify job runs as a required check
- Push to main: verify → deploy (unchanged net effect, just with a gate)
- Manual deploy (workflow_dispatch on main): unchanged