### PR TITLE
deps: zod 3.24.4 → 4.3.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@cloudflare/workers-oauth-provider": "^0.4.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "hono": "^4.12.14",
-        "zod": "^3.24.4"
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20260421.1",
@@ -2649,9 +2649,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@cloudflare/workers-oauth-provider": "^0.4.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "hono": "^4.12.14",
-    "zod": "^3.24.4"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260421.1",


### PR DESCRIPTION
Bumps zod across a major version. Every schema in src/schemas/inputs.ts uses the subset of the zod API that is source-compatible between v3 and v4:

  z.object({...})
  z.string(), z.enum([...])
  z.coerce.number().int().positive()
  .optional(), .default(), .min, .max

`npm run typecheck` and `npm run build` both pass with zero diffs outside package.json / package-lock.json. Same outcome the sibling HaloPSA connector saw when it made this bump.

`npm audit` continues to report 0 vulnerabilities.

Bundle size grew 959 → 1414 KiB (gzipped: 183 → 240 KiB) — zod v4 is a bit larger, but well within Workers' 10 MiB compressed limit.