### PR TITLE
feat: add hudu_list_magic_dash + fix HuduMagicDash type

### DIFF
--- a/src/formatters/markdown.ts
+++ b/src/formatters/markdown.ts
@@ -14,6 +14,7 @@ import type {
   HuduNetwork,
   HuduIpAddress,
   HuduVlan,
+  HuduMagicDash,
   HuduPagedResponse,
 } from "../types";
 
@@ -462,6 +463,23 @@ export function formatVlanList(paged: HuduPagedResponse<HuduVlan>): string {
     "",
     "| ID | VID | Name | Description |",
     "|---|---|---|---|",
+    ...rows,
+  ].join("\n");
+}
+
+export function formatMagicDashList(widgets: HuduMagicDash[]): string {
+  if (widgets.length === 0) return "No Magic Dash widgets found.";
+
+  const rows = widgets.map(
+    (w) =>
+      `| ${w.id} | ${esc(w.title)} | ${esc(w.company_name)} | ${w.company_id ?? ""} | ${w.shade ?? ""} | ${truncate(w.message, 60)} |`
+  );
+
+  return [
+    `**${widgets.length} Magic Dash widget${widgets.length === 1 ? "" : "s"}**`,
+    "",
+    "| ID | Title | Company | Company ID | Shade | Message |",
+    "|---|---|---|---|---|---|",
     ...rows,
   ].join("\n");
 }

--- a/src/schemas/inputs.ts
+++ b/src/schemas/inputs.ts
@@ -217,6 +217,15 @@ export const updateArticleSchema = z.object({
   folder_id: z.coerce.number().int().positive().optional().describe("Move article to a different folder"),
 });
 
+export const listMagicDashSchema = z.object({
+  company_id: z.coerce.number().int().positive().optional().describe(
+    "Filter widgets by company ID. If omitted, returns widgets across all companies."
+  ),
+  title: z.string().optional().describe(
+    "Filter by exact widget title match. Useful for checking whether a widget with a specific title already exists (Magic Dash upserts by title+company)."
+  ),
+});
+
 export const createMagicDashSchema = z.object({
   title: z.string().describe("Magic Dash widget title"),
   company_name: z.string().optional().describe("Company name to associate the widget with"),

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -10,6 +10,7 @@ import { register as registerActivityLogs } from "./activity-logs";
 import { register as registerFolders } from "./folders";
 import { register as registerUsersGroups } from "./users-groups";
 import { register as registerRelations } from "./relations";
+import { register as registerMagicDash } from "./magic-dash";
 
 export function registerAllTools(server: McpServer, env: Env) {
   // Phase 1: Read-only tools for QBR automation and cross-reference
@@ -24,7 +25,8 @@ export function registerAllTools(server: McpServer, env: Env) {
   registerFolders(server, env);
   registerUsersGroups(server, env);
   registerRelations(server, env);
+  registerMagicDash(server, env); // read-only: hudu_list_magic_dash
 
-  // Phase 2: Write tools (magic-dash.ts, create/update assets & articles)
+  // Phase 2: Write tools (create/update assets & articles, magic dash writes on local-dev)
   // Phase 3: Networks (networks.ts)
 }

--- a/src/tools/magic-dash.ts
+++ b/src/tools/magic-dash.ts
@@ -1,0 +1,44 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { listMagicDashSchema } from "../schemas/inputs";
+import { huduFetch } from "../api-client";
+import { formatMagicDashList } from "../formatters/markdown";
+import type { HuduMagicDash } from "../types";
+
+export function register(server: McpServer, env: Env) {
+  server.registerTool(
+    "hudu_list_magic_dash",
+    {
+      description:
+        "List Magic Dash widgets. Optionally filter by company_id or exact title. Returns a flat array (Hudu does not paginate this endpoint). Useful for checking what widgets already exist on a company before creating/updating one, since Magic Dash upserts by (title, company).",
+      inputSchema: listMagicDashSchema,
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        openWorldHint: true,
+      },
+    },
+    async (args) => {
+      try {
+        const widgets = await huduFetch<HuduMagicDash[]>(env, "magic_dash", {
+          company_id: args.company_id,
+          title: args.title,
+        });
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: formatMagicDashList(Array.isArray(widgets) ? widgets : []),
+            },
+          ],
+        };
+      } catch (err) {
+        console.error(
+          "[hudu_list_magic_dash]",
+          err instanceof Error ? err.message : String(err)
+        );
+        throw err;
+      }
+    }
+  );
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -283,6 +283,9 @@ export interface HuduGroup {
 }
 
 // ---- Magic Dash ----
+// Verified against live GET /magic_dash and POST /magic_dash responses:
+// the response does NOT include created_at / updated_at, but does
+// include a `position` field for ordering within a company.
 
 export interface HuduMagicDash {
   id: number;
@@ -295,8 +298,7 @@ export interface HuduMagicDash {
   content_link: string | null;
   content: string | null;
   shade: string | null;
-  created_at: string;
-  updated_at: string;
+  position: number | null;
 }
 
 // ---- Networks ----


### PR DESCRIPTION
New tool:
- hudu_list_magic_dash: GET /magic_dash with optional company_id and title filters. Returns a flat array (Hudu does not paginate this endpoint). Use case: check what Magic Dash widgets already exist on a company before creating/updating one, since Magic Dash upserts by (title, company).

Type fix (bugfix — the old type described fields that don't exist):
- HuduMagicDash: remove created_at and updated_at (verified against live Hudu responses — they are never returned).
- Add `position: number | null` which IS returned (orders widgets within a company page).

Read-only, safe for production — no OAuth scope changes, no new env vars, no allowlist needed. Registered in registerAllTools alongside the other 17 read tools.

Verified via live smoke test against the Hudu production tenant (MCP Sandbox company, id 64):
- GET /magic_dash (no filter) → array of all widgets
- GET /magic_dash?company_id=64 → filtered to sandbox
- GET /magic_dash?title=X → exact title match
- GET /magic_dash/:id → 404 (the single-item endpoint does not exist, hence the "list only" design)

Part of the Phase 2 Magic Dash effort. A follow-up branch will promote hudu_create_magic_dash from local-dev with email-allowlist gating; this list tool lands first because it carries no write risk.