### PR TITLE
fix(api-client): set User-Agent so Cloudflare WAF doesn't 403 Hudu calls

### DIFF
--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -1,5 +1,10 @@
 import type { HuduPagedResponse } from "./types";
 
+// Cloudflare WAF in front of docs.networkzit.com blocks requests with the default
+// undici/Workers User-Agent. An identified bot UA passes; without this the API
+// returns 403 with a Cloudflare HTML interstitial instead of JSON.
+const USER_AGENT = "nit-mcp-hudu/1.0 (+https://github.com/Networkz-IT/nit-mcp-hudu)";
+
 /**
  * Parse JSON safely, throwing a contextual error on failure.
  */
@@ -43,6 +48,7 @@ export async function huduFetch<T>(
     headers: {
       "x-api-key": env.HUDU_API_KEY,
       "Content-Type": "application/json",
+      "User-Agent": USER_AGENT,
     },
   });
 
@@ -86,6 +92,7 @@ export async function huduMutate<T>(
     headers: {
       "x-api-key": env.HUDU_API_KEY,
       "Content-Type": "application/json",
+      "User-Agent": USER_AGENT,
     },
     body: body ? JSON.stringify(body) : undefined,
   });


### PR DESCRIPTION
## Summary
- Production Hudu MCP calls started returning 403 (Cloudflare HTML interstitial, not Hudu JSON). Root cause: Cloudflare WAF in front of `docs.networkzit.com` blocks the default Workers/undici `User-Agent`. Likely tightened around the Hudu 2.41.2 upgrade.
- Fix: send an identified bot UA (`nit-mcp-hudu/1.0 (+https://github.com/Networkz-IT/nit-mcp-hudu)`) on every Hudu request from both `huduFetch` and `huduMutate`.

## Verification
Local probe with the same UA against the prod Hudu API:
```
/companies   200  application/json   1 record(s)
/assets      200  application/json   1 record(s)
/articles    200  application/json   1 record(s)
```
Other UAs tested for context: default undici → 403, empty → 403, `curl/8.5.0` → 403, identified bot → 200, real Chrome → 200.

`npm run typecheck` clean.

## Test plan
- [ ] CI verify gate (typecheck + build + npm audit) passes
- [ ] After merge + deploy, retry the failing `hudu_list_articles` call from the MCP client
- [ ] Confirm `wrangler tail` shows 200s on Hudu requests, no `[hudu] API error 403`

🤖 Generated with [Claude Code](https://claude.com/claude-code)