### PR TITLE
deps: @cloudflare/workers-types 4.20260422.1 → 4.20260507.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "zod": "^4.3.6"
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "^4.20260421.1",
+        "@cloudflare/workers-types": "^4.20260507.1",
         "typescript": "^5.9.3",
         "wrangler": "^4.84.1"
       }
@@ -145,9 +145,9 @@
       "license": "MIT"
     },
     "node_modules/@cloudflare/workers-types": {
-      "version": "4.20260422.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260422.1.tgz",
-      "integrity": "sha512-kI4baXLJloST4J/PxAfhz3azy4TPC7L2wcX6nusOzSNJJD/L5CSsivSJobgkYaMG5yspzRFQUQlCdPza0nTHbQ==",
+      "version": "4.20260507.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260507.1.tgz",
+      "integrity": "sha512-QChtMFu8EeVKaL4dW5r5wfZzlbH5CUnZU5Ef6E1cPjXzqryQuCwmEDNr+Oj2obbKR9jsVIUHPF/pkFaKWdYl2g==",
       "dev": true,
       "license": "MIT OR Apache-2.0"
     },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20260421.1",
+    "@cloudflare/workers-types": "^4.20260507.1",
     "typescript": "^5.9.3",
     "wrangler": "^4.84.1"
   }


### PR DESCRIPTION
## Summary
- Refresh date-stamped Workers types to the latest snapshot.
- Type-only dev dep — does not affect runtime behavior.

## Verification
- npm run typecheck: clean
- npm run build: clean
- npm audit: 0 vulnerabilities

## Test plan
- [ ] CI verify gate passes (typecheck + build + audit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)