### PR TITLE
deps: zod 4.3.6 → 4.4.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@cloudflare/workers-oauth-provider": "^0.4.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "hono": "^4.12.14",
-        "zod": "^4.3.6"
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20260507.1",
@@ -2649,9 +2649,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@cloudflare/workers-oauth-provider": "^0.4.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "hono": "^4.12.14",
-    "zod": "^4.3.6"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260507.1",


### PR DESCRIPTION
## Summary
- Direct runtime dep used in `src/schemas/inputs.ts` for all tool input validation.
- Patch + minor bump (4.3.6 → 4.4.3). No vulnerabilities; this is a maintenance refresh.

## Changelog review (4.4.0 → 4.4.3) vs our API surface

We use only: `z.object`, `z.string`, `z.number`, `z.boolean`, `z.enum`, `z.array`, `z.union`, `z.coerce`, plus `.default()` on scalars and `.describe()`. Verified via `grep` — no usage of `z.tuple`, `z.discriminatedUnion`, `z.preprocess`, `.catch()`, `.transform()`, or `.refine()`.

| Version | Notable change | Impact |
|---|---|---|
| 4.4.0 | Tuple default materialization, tuple length error consistency | None — no tuples |
| 4.4.1 | Reject tuple holes before required defaults | None |
| 4.4.2 | Discriminated union typing tightening; `z.preprocess` defers optionality | None — we use `z.union` |
| 4.4.3 | Restore `.catch()` handling for absent object keys; `preprocess` on absent keys | None |

## Verification
- npm run typecheck: clean
- npm run build: clean
- npm audit: 0 vulnerabilities

## Test plan
- [ ] CI verify gate passes
- [ ] After deploy, smoke-test a couple of read tools (`hudu_list_companies`, `hudu_list_articles`) to confirm input validation still accepts the same shapes

🤖 Generated with [Claude Code](https://claude.com/claude-code)