### PR TITLE
deps: @cloudflare/workers-oauth-provider 0.4.0 → 0.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "nit-mcp-hudu",
       "version": "1.0.0",
       "dependencies": {
-        "@cloudflare/workers-oauth-provider": "^0.4.0",
+        "@cloudflare/workers-oauth-provider": "^0.5.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "hono": "^4.12.14",
         "zod": "^4.4.3"
@@ -139,9 +139,9 @@
       }
     },
     "node_modules/@cloudflare/workers-oauth-provider": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-oauth-provider/-/workers-oauth-provider-0.4.0.tgz",
-      "integrity": "sha512-UtbV8hjC2NloB+Ds6J6v/9HiG8rx8MbdeYGCyFwOACT5vANWzDL6SKo3W5UZymsXiameAgC7jAmtUx4cc+Qpaw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-oauth-provider/-/workers-oauth-provider-0.5.0.tgz",
+      "integrity": "sha512-KlqhvvG6XAkemDlckeiqpMpXzYjpfW+IXkxfIHJOxnrotfZdVVkeiAMTTtmYBizwvY/t6FtR9d2Da+NZLboM5g==",
       "license": "MIT"
     },
     "node_modules/@cloudflare/workers-types": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@cloudflare/workers-oauth-provider": "^0.4.0",
+    "@cloudflare/workers-oauth-provider": "^0.5.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "hono": "^4.12.14",
     "zod": "^4.4.3"


### PR DESCRIPTION
## Summary
Bumps the OAuth provider that gates `/mcp`. 0.5.0 is a focused minor release: KV TTL defaults and cascade deletes to prevent unbounded namespace growth.

We are already on 0.4.0, so the path-aware resource URI changes from 0.4.0 (RFC 9728 §3.1 / §5.1) are already in production.

## Behavior changes that ship with 0.5.0

| Change | Impact here |
|---|---|
| `refreshTokenTTL` now defaults to **30 days** (was infinite) | New refresh tokens auto-expire after 30 days via KV TTL. Users re-auth via Entra. Existing 0.4.0-issued refresh tokens are NOT retroactively affected (KV TTL only applies to new writes). |
| New `clientRegistrationTTL` defaults to **90 days** | Applies to DCR-registered clients via `/register` (our endpoint). New clients (Claude Desktop/Code etc) auto-expire after 90 days; they re-register transparently. Existing clients unaffected. |
| `deleteClient()` now cascades to grants and tokens | We don't call `deleteClient`. No impact. |
| New `purgeExpiredData()` method | Optional, designed for a Cron Trigger. Not enabled here. Possible defense-in-depth follow-up. |

No constructor option or API signature changes affect our usage in `src/index.ts` or `src/auth-handler.ts`.

## Risk assessment
- **Low.** Existing sessions are preserved. New sessions inherit the 30/90-day TTLs, which align with reasonable security defaults for an MCP server.
- If we ever wanted infinite refresh tokens we'd have to set `refreshTokenTTL: undefined` explicitly. Not recommended.

## Verification
- npm run typecheck: clean
- npm run build: clean
- npm audit: 0 vulnerabilities

## Test plan
- [ ] CI verify gate passes
- [ ] After deploy, sign in fresh from an MCP client to confirm OAuth flow still works end-to-end (`/authorize` → Entra → `/callback` → tool call returns 200)

## Possible follow-ups (separate PR)
- Add a Cron Trigger that calls `oauthProvider.purgeExpiredData(env)` weekly for KV hygiene.

🤖 Generated with [Claude Code](https://claude.com/claude-code)