### PR TITLE
deps: typescript 5.9.3 → 6.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20260507.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "wrangler": "^4.88.0"
       }
     },
@@ -2452,9 +2452,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260507.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "wrangler": "^4.88.0"
   }
 }


### PR DESCRIPTION
## Summary
Major bump of the TypeScript build toolchain.

## De-risking
Sibling project `nit-mcp-halo-proj01` has already deployed TS 6 with no impact. Both projects share the same toolchain profile: wrangler, `@cloudflare/workers-types`, hono, MCP SDK, zod, `@cloudflare/workers-oauth-provider`. No project-specific TS features in use here that aren't also in halo.

## Verification
- `npx tsc --version`: 6.0.3
- `npm run typecheck`: clean, no source changes required
- `npm run build`: clean
- `npm audit`: 0 vulnerabilities
- No `tsconfig.json` adjustments needed

## Test plan
- [ ] CI verify gate passes (typecheck + build + audit)
- [ ] Deploy succeeds (build output identical structure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)