### PR TITLE
chore: declare engines.node >=22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,9 @@
         "@cloudflare/workers-types": "^4.20260507.1",
         "typescript": "^6.0.3",
         "wrangler": "^4.88.0"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@cfworker/json-schema": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "Hudu MCP Server for Cloudflare Workers",
   "private": true,
   "type": "module",
+  "engines": {
+    "node": ">=22"
+  },
   "scripts": {
     "build": "tsc",
     "dev": "wrangler dev",


### PR DESCRIPTION
## Summary
Declare `"engines": { "node": ">=22" }` in `package.json`.

## Why
The wrangler 4.88.x bump (PR #46) introduced a Node >= 22 requirement. CI is already on Node 22 (`.github/workflows/deploy.yml`), but local dev environments on Node 20 would hit a confusing wrangler runtime error rather than a clear install-time signal. Declaring the engines field surfaces the version mismatch up front:

- `npm install` shows an EBADENGINE warning by default
- `npm config set engine-strict true` (or `.npmrc` with `engine-strict=true`) makes it a hard failure

## Verification
- `npm install`: clean, lockfile picks up the engines field
- `npm run typecheck`: clean
- `npm run build`: clean
- `npm audit`: 0 vulnerabilities

## Test plan
- [x] CI verify gate passes
- [ ] (Manual, optional) On a Node 20 box, confirm `npm install` warns with EBADENGINE

🤖 Generated with [Claude Code](https://claude.com/claude-code)