### PR TITLE
chore: read OAuth redirect base URL from PUBLIC_BASE_URL env var

### DIFF
--- a/env.d.ts
+++ b/env.d.ts
@@ -7,4 +7,5 @@ interface Env {
   ENTRA_TENANT_ID: string;
   ENTRA_CLIENT_ID: string;
   ENTRA_CLIENT_SECRET: string;
+  PUBLIC_BASE_URL: string;
 }

--- a/src/auth-handler.ts
+++ b/src/auth-handler.ts
@@ -1,14 +1,12 @@
 import type { AuthRequest, OAuthHelpers } from "@cloudflare/workers-oauth-provider";
 import { Hono } from "hono";
 
-const PROD_URL = "https://nit-mcp-hudu.nit-7ac.workers.dev";
-
-function getWorkerUrl(req: Request): string {
+function getWorkerUrl(req: Request, env: Bindings): string {
   const url = new URL(req.url);
   if (url.hostname === "localhost" || url.hostname === "127.0.0.1") {
     return `${url.protocol}//${url.host}`;
   }
-  return PROD_URL;
+  return getRequiredEnv(env, "PUBLIC_BASE_URL");
 }
 
 type Bindings = Env & { OAUTH_PROVIDER: OAuthHelpers };
@@ -123,7 +121,7 @@ app.get("/authorize", async (c) => {
   );
   entraAuthorizeUrl.searchParams.set("client_id", clientId);
   entraAuthorizeUrl.searchParams.set("response_type", "code");
-  const workerUrl = getWorkerUrl(c.req.raw);
+  const workerUrl = getWorkerUrl(c.req.raw, c.env);
   entraAuthorizeUrl.searchParams.set("redirect_uri", `${workerUrl}/callback`);
   entraAuthorizeUrl.searchParams.set("scope", "openid email profile User.Read");
   entraAuthorizeUrl.searchParams.set("state", state);
@@ -186,7 +184,7 @@ app.get("/callback", async (c) => {
     client_id: clientId,
     client_secret: clientSecret,
     code,
-    redirect_uri: `${getWorkerUrl(c.req.raw)}/callback`,
+    redirect_uri: `${getWorkerUrl(c.req.raw, c.env)}/callback`,
     grant_type: "authorization_code",
   });
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -7,6 +7,7 @@ account_id = "7ac71ffa8a171e8755646124094cb9f3"
 [vars]
 HUDU_BASE_URL = "https://docs.networkzit.com/api/v1"
 ENTRA_TENANT_ID = "6c9b4558-affd-4a18-9494-fb95f1ed92d1"
+PUBLIC_BASE_URL = "https://hudu-mcp.networkzit.com"
 
 # Secrets (push via: wrangler secret put <NAME>):
 # HUDU_API_KEY


### PR DESCRIPTION
## Summary

- Replaces the hardcoded `PROD_URL` constant in `src/auth-handler.ts` with a `PUBLIC_BASE_URL` env var read via `getRequiredEnv`.
- Sets `PUBLIC_BASE_URL = https://hudu-mcp.networkzit.com` in `wrangler.toml [vars]` so the OAuth `/callback` `redirect_uri` matches the new custom domain.
- Localhost dev-mode branch in `getWorkerUrl` is unchanged.

Without this change, any OAuth flow initiated at `hudu-mcp.networkzit.com/authorize` redirects users to a `redirect_uri` on the old `workers.dev` host, breaking sign-in on the new domain.

First in a stack of small PRs implementing the security hardening plan (custom domain, WAF in front, Entra app role, headers, audit log).

## Test plan

- [ ] Confirm typecheck passes (`npm run typecheck`).
- [ ] Deploy worker; complete the OAuth flow at `https://hudu-mcp.networkzit.com/authorize` and confirm `/callback` resolves on the same host (not workers.dev).
- [ ] Confirm Entra app registration has `https://hudu-mcp.networkzit.com/callback` listed as a redirect URI before merging (otherwise Entra rejects the redirect).

🤖 Generated with [Claude Code](https://claude.com/claude-code)