### PR TITLE
feat: split health endpoint to /healthz, minimize root response

### DIFF
--- a/src/auth-handler.ts
+++ b/src/auth-handler.ts
@@ -96,9 +96,15 @@ async function verifyState(state: string, secret: string): Promise<string | null
   return new TextDecoder().decode(fromBase64Url(payloadB64));
 }
 
-// Health check
+// Stable health endpoint for uptime probes; intentionally exempt from WAF
+// country/bot rules so external monitors in any geo can reach it.
+app.get("/healthz", (c) => {
+  return c.json({ server: "hudu-mcp", version: "1.0.0", status: "ok" });
+});
+
+// Root: minimal landing; avoids leaking version info to unauthenticated callers.
 app.get("/", (c) => {
-  return c.json({ server: "hudu-mcp", version: "1.0.0" });
+  return c.text("OK", 200);
 });
 
 // OAuth authorize: redirect user to Entra ID


### PR DESCRIPTION
## Summary

- `GET /healthz` returns the structured JSON health payload (`server`, `version`, `status`) for uptime probes. Intended to be exempt from the WAF country/bot rules so external monitors can reach it from any geo.
- `GET /` now returns plain `OK` 200, dropping the `server`/`version` disclosure on the unauthenticated landing endpoint.

This lets the WAF US-only geo block apply broadly without breaking uptime monitoring, and tightens the public surface.

Part of the security hardening stack. Independent of #57 (PUBLIC_BASE_URL); can land in any order.

## Test plan

- [ ] `curl https://hudu-mcp.networkzit.com/healthz` returns JSON `{server, version, status:"ok"}`.
- [ ] `curl https://hudu-mcp.networkzit.com/` returns plain `OK` (no version leak).
- [ ] Update the WAF country/bot rules to exempt `http.request.uri.path eq "/healthz"` after merge.
- [ ] If any external uptime monitor was pointed at `/`, repoint it to `/healthz`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)