### PR TITLE
feat: add Hono secureHeaders middleware + no-store on OAuth endpoints

### DIFF
--- a/src/auth-handler.ts
+++ b/src/auth-handler.ts
@@ -1,5 +1,6 @@
 import type { AuthRequest, OAuthHelpers } from "@cloudflare/workers-oauth-provider";
 import { Hono } from "hono";
+import { secureHeaders } from "hono/secure-headers";
 
 const PROD_URL = "https://nit-mcp-hudu.nit-7ac.workers.dev";
 
@@ -14,6 +15,27 @@ function getWorkerUrl(req: Request): string {
 type Bindings = Env & { OAUTH_PROVIDER: OAuthHelpers };
 
 const app = new Hono<{ Bindings: Bindings }>();
+
+app.use(
+  "*",
+  secureHeaders({
+    strictTransportSecurity: "max-age=31536000; includeSubDomains; preload",
+    referrerPolicy: "no-referrer",
+    xContentTypeOptions: "nosniff",
+    xFrameOptions: "DENY",
+    removePoweredBy: true,
+  })
+);
+
+// OAuth endpoints must not be cached by browsers or intermediaries:
+// state, code, and redirect URLs are single-use and tied to a nonce.
+const noStore: import("hono").MiddlewareHandler = async (c, next) => {
+  await next();
+  c.header("Cache-Control", "no-store");
+  c.header("Pragma", "no-cache");
+};
+app.use("/authorize", noStore);
+app.use("/callback", noStore);
 
 const NONCE_TTL_SECONDS = 600;
 


### PR DESCRIPTION
## Summary

- Wires `hono/secure-headers` globally on the Hono `app` with HSTS (1y, includeSubDomains, preload), Referrer-Policy `no-referrer`, X-Content-Type-Options `nosniff`, X-Frame-Options `DENY`, and `removePoweredBy`.
- Adds a small `Cache-Control: no-store` (+ `Pragma: no-cache`) middleware scoped to `/authorize` and `/callback` so OAuth state/code/redirect URLs are never cached by browsers or intermediaries.

Part of the security hardening stack. Independent of #57 and #58.

## Test plan

- [ ] `curl -I https://hudu-mcp.networkzit.com/healthz` shows `strict-transport-security`, `referrer-policy: no-referrer`, `x-content-type-options: nosniff`, `x-frame-options: DENY`. No `x-powered-by`.
- [ ] `curl -I https://hudu-mcp.networkzit.com/authorize?...` (or follow the full flow) shows `cache-control: no-store`.
- [ ] Complete one OAuth flow end-to-end and confirm no regression.
- [ ] Note: HSTS `includeSubDomains` only affects sub-subdomains of `hudu-mcp.networkzit.com`; it does not propagate to siblings like `docs.networkzit.com`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)