### PR TITLE
feat: emit structured audit log for every /mcp request

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,8 +10,42 @@ export type Props = {
   entraId: string;
 };
 
+// OAuthProvider attaches the authenticated grant's props onto ctx.props
+// before invoking the apiHandler. Standard ExecutionContext does not type this.
+type AuthedExecutionContext = ExecutionContext & { props?: Props };
+
+type McpRequestEnvelope = {
+  method?: string;
+  params?: { name?: string };
+  id?: string | number;
+};
+
+async function peekMcpRequest(request: Request): Promise<{
+  mcpMethod?: string;
+  toolName?: string;
+  rpcId?: string | number;
+}> {
+  if (request.method !== "POST") return {};
+  try {
+    const cloned = request.clone();
+    const body = (await cloned.json()) as McpRequestEnvelope;
+    return {
+      mcpMethod: body.method,
+      toolName: body.method === "tools/call" ? body.params?.name : undefined,
+      rpcId: body.id,
+    };
+  } catch {
+    // Non-JSON or empty body — nothing to log beyond the wrapper fields.
+    return {};
+  }
+}
+
 const apiHandler = {
-  async fetch(request: Request, env: Env, _ctx: ExecutionContext): Promise<Response> {
+  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+    const start = Date.now();
+    const props = (ctx as AuthedExecutionContext).props;
+    const { mcpMethod, toolName, rpcId } = await peekMcpRequest(request);
+
     const server = new McpServer({
       name: "hudu-mcp",
       version: "1.0.0",
@@ -26,9 +60,24 @@ const apiHandler = {
 
     await server.connect(transport);
 
+    let status = 0;
     try {
-      return await transport.handleRequest(request);
+      const response = await transport.handleRequest(request);
+      status = response.status;
+      return response;
     } finally {
+      console.log(
+        JSON.stringify({
+          type: "audit",
+          email: props?.email,
+          entraId: props?.entraId,
+          mcpMethod,
+          tool: toolName,
+          rpcId,
+          status,
+          durationMs: Date.now() - start,
+        })
+      );
       await transport.close();
       await server.close();
     }


### PR DESCRIPTION
## Summary

- Wraps `apiHandler.fetch` in `src/index.ts` to emit a single structured JSON log line per request: `{ type: "audit", email, entraId, mcpMethod, tool, rpcId, status, durationMs }`.
- Reads the authenticated user from `ctx.props` (OAuthProvider populates this from the validated grant).
- Extracts the JSON-RPC `method` and (for `tools/call`) the tool `name` by peeking a cloned Request body — the original Request body is left untouched for the MCP transport.
- Logs flow to the existing `grafana-logs` observability destination already configured in `wrangler.toml`.

Required as a SOX / 21 CFR Part 11 review trail before Phase 2 write tools land. Independent of #57, #58, #59.

## Test plan

- [ ] Deploy and run one tool call (e.g., `hudu_list_companies`) from Claude Desktop.
- [ ] Check the Cloudflare Logs / Grafana destination for a single `{"type":"audit", ...}` entry with non-empty `email` and `tool: "hudu_list_companies"`.
- [ ] Confirm no token/secret material is in the log line.
- [ ] Confirm `status` matches the HTTP response code observed by the client.
- [ ] Sanity-check that the MCP transport still receives a readable body (request cloning is non-consumptive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)