### PR TITLE
feat: structured per-call log line for every Hudu API request

### DIFF
--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -6,6 +6,31 @@ import type { HuduPagedResponse } from "./types";
 const USER_AGENT = "nit-mcp-hudu/1.0 (+https://github.com/Networkz-IT/nit-mcp-hudu)";
 
 /**
+ * Strip query string and numeric IDs from an endpoint so log cardinality
+ * stays bounded (e.g. "companies/64/assets?page=2" -> "companies/:id/assets").
+ */
+function normalizeEndpoint(endpoint: string): string {
+  return endpoint.split("?")[0].replace(/\/\d+/g, "/:id");
+}
+
+function logHuduCall(
+  method: string,
+  endpoint: string,
+  status: number,
+  durationMs: number
+): void {
+  console.log(
+    JSON.stringify({
+      type: "hudu_api",
+      method,
+      endpoint: normalizeEndpoint(endpoint),
+      status,
+      durationMs,
+    })
+  );
+}
+
+/**
  * Parse JSON safely, throwing a contextual error on failure.
  */
 function safeJsonParse<T>(text: string, endpoint: string): T {
@@ -44,6 +69,7 @@ export async function huduFetch<T>(
     }
   }
 
+  const start = Date.now();
   const response = await fetch(url.toString(), {
     headers: {
       "x-api-key": env.HUDU_API_KEY,
@@ -53,6 +79,7 @@ export async function huduFetch<T>(
   });
 
   const text = await response.text();
+  logHuduCall("GET", endpoint, response.status, Date.now() - start);
 
   if (response.status === 429) {
     throw new Error(
@@ -61,7 +88,6 @@ export async function huduFetch<T>(
   }
 
   if (!response.ok) {
-    console.error(`[hudu] API error ${response.status} for ${endpoint}`);
     throw new Error(
       `Hudu API request failed (${response.status}) for ${endpoint}. Check the resource ID and try again.`
     );
@@ -87,6 +113,7 @@ export async function huduMutate<T>(
 
   const url = new URL(`${env.HUDU_BASE_URL}/${endpoint}`);
 
+  const start = Date.now();
   const response = await fetch(url.toString(), {
     method,
     headers: {
@@ -98,6 +125,7 @@ export async function huduMutate<T>(
   });
 
   const text = await response.text();
+  logHuduCall(method, endpoint, response.status, Date.now() - start);
 
   if (response.status === 429) {
     throw new Error(
@@ -106,7 +134,6 @@ export async function huduMutate<T>(
   }
 
   if (!response.ok) {
-    console.error(`[hudu] API error ${response.status} for ${method} ${endpoint}`);
     throw new Error(
       `Hudu API request failed (${response.status}) for ${method} ${endpoint}. Check the resource ID and try again.`
     );


### PR DESCRIPTION
## Summary

- Emits one `console.log` line per `huduFetch` / `huduMutate` call: `{ type: "hudu_api", method, endpoint, status, durationMs }`.
- `endpoint` is normalized (numeric IDs → `:id`, query string stripped) so Grafana/Loki label cardinality stays bounded.
- Replaces the two ad-hoc `console.error` lines that previously fired only on non-OK responses; the structured line now carries the same information on every call regardless of outcome. Operators filter by `status>=400` instead of grepping for `"[hudu] API error"`.

Powers Dashboard D (Hudu API budget): calls/min vs 300/min headroom, top endpoints by call count, p95 latency, 429 trend.

## Test plan

- [ ] Deploy. After one `hudu_list_companies` tool call, confirm a Loki entry like `{"type":"hudu_api","method":"GET","endpoint":"companies","status":200,"durationMs":...}`.
- [ ] After a call against `companies/:id/assets`, confirm the logged endpoint reads `companies/:id/assets` (numeric ID normalized).
- [ ] Force a 429 (run scripts/smoke.ts in a tight loop, or hammer one tool) and confirm a single structured line with `status:429`.
- [ ] Confirm the legacy `[hudu] API error ...` text lines no longer appear (replaced by structured form).

## Follow-up (out of scope)

Per-tool attribution requires plumbing the MCP tool name down to the API client. Doable with AsyncLocalStorage (nodejs_compat is on) — separate PR if Dashboard D shows it'd be valuable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)