### PR TITLE
fix: return 400 (not 500) when /authorize is hit without OAuth params

### DIFF
--- a/src/auth-handler.ts
+++ b/src/auth-handler.ts
@@ -133,7 +133,18 @@ app.get("/authorize", async (c) => {
   const clientId = getRequiredEnv(c.env, "ENTRA_CLIENT_ID");
   const clientSecret = getRequiredEnv(c.env, "ENTRA_CLIENT_SECRET");
 
-  const oauthReqInfo = await c.env.OAUTH_PROVIDER.parseAuthRequest(c.req.raw);
+  // parseAuthRequest throws on missing/malformed OAuth query params. Treat
+  // that as a 400 (caller error) rather than a 500 (server bug) so direct
+  // browser hits and stale-bookmark probes don't pollute exception metrics.
+  let oauthReqInfo;
+  try {
+    oauthReqInfo = await c.env.OAUTH_PROVIDER.parseAuthRequest(c.req.raw);
+  } catch {
+    return c.text(
+      "This URL is part of the OAuth sign-in flow. Open Hudu through your MCP client (Claude Desktop or Claude Code) instead.",
+      400
+    );
+  }
   if (!oauthReqInfo.clientId) {
     return c.text("Invalid OAuth request", 400);
   }


### PR DESCRIPTION
## Summary

Wraps `OAUTH_PROVIDER.parseAuthRequest` in try/catch. When required OAuth query params (`client_id`, `redirect_uri`, etc.) are missing or malformed, `parseAuthRequest` throws — which previously bubbled to Hono and produced a **500**. Direct browser visits, stale bookmarks, and scanner probes all generated spurious 5xx events.

Now returns a **400** with a friendly hint: "This URL is part of the OAuth sign-in flow. Open Hudu through your MCP client (Claude Desktop or Claude Code) instead."

Cleans up alert noise once we wire 5xx-rate alerts in Grafana — real bugs no longer hide behind expected user errors.

## Test plan

- [ ] `curl -H "User-Agent: Mozilla/5.0" https://hudu-mcp.networkzit.com/authorize` returns **400** (not 500) with the friendly message.
- [ ] A real OAuth flow from the MCP client still completes (parseAuthRequest succeeds, no regression).
- [ ] `curl https://hudu-mcp.networkzit.com/authorize` (default curl UA) still returns **403** from the WAF (rule 4 unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)