### PR TITLE
Phase 1.6: Flags, VLANs, VLAN Zones, Procedure Tasks + filter enhancements

### DIFF
--- a/src/formatters/markdown.ts
+++ b/src/formatters/markdown.ts
@@ -19,6 +19,10 @@ import type {
   HuduPasswordFolder,
   HuduUpload,
   HuduAppInfo,
+  HuduVlanZone,
+  HuduFlag,
+  HuduFlagType,
+  HuduProcedureTask,
   HuduPagedResponse,
 } from "../types";
 
@@ -457,20 +461,201 @@ export function formatIpAddressList(records: HuduIpAddress[]): string {
   ].join("\n");
 }
 
-export function formatVlanList(paged: HuduPagedResponse<HuduVlan>): string {
-  if (paged.records.length === 0) return "No VLANs found.";
+// VLANs are returned as a bare array (no pagination).
+
+export function formatVlanList(records: HuduVlan[]): string {
+  if (records.length === 0) return "No VLANs found.";
+
+  const rows = records.map(
+    (v) => `| ${v.id} | ${v.vlan_id ?? "-"} | ${esc(v.name)} | ${v.company_id} | ${v.vlan_zone_id ?? "-"} | ${v.networks_count ?? "-"} |`
+  );
+
+  return [
+    `**${records.length} VLANs**`,
+    "",
+    "| ID | VLAN # | Name | Company ID | Zone ID | Networks |",
+    "|---|---|---|---|---|---|",
+    ...rows,
+  ].join("\n");
+}
+
+export function formatVlanDetail(v: HuduVlan): string {
+  return [
+    `# VLAN: ${esc(v.name) || v.id}`,
+    "",
+    "| Field | Value |",
+    "|---|---|",
+    `| ID | ${v.id} |`,
+    `| Name | ${esc(v.name) || "-"} |`,
+    `| VLAN # | ${v.vlan_id ?? "-"} |`,
+    `| Company ID | ${v.company_id} |`,
+    `| Zone ID | ${v.vlan_zone_id ?? "-"} |`,
+    `| Status (list item) | ${v.status_list_item_id ?? "-"} |`,
+    `| Role (list item) | ${v.role_list_item_id ?? "-"} |`,
+    `| Networks count | ${v.networks_count ?? "-"} |`,
+    `| Hudu URL | ${esc(v.url) || "-"} |`,
+    `| Archived | ${v.archived_at ?? "No"} |`,
+    `| Created | ${v.created_at ?? ""} |`,
+    `| Updated | ${v.updated_at ?? ""} |`,
+    ...(v.description ? ["", "## Description", "", truncate(v.description, 2000)] : []),
+    ...(v.notes ? ["", "## Notes", "", truncate(v.notes, 2000)] : []),
+  ].join("\n");
+}
+
+// ---- VLAN Zones ----
+
+export function formatVlanZoneList(records: HuduVlanZone[]): string {
+  if (records.length === 0) return "No VLAN Zones found.";
+
+  const rows = records.map(
+    (z) => `| ${z.id} | ${esc(z.name)} | ${z.company_id} | ${esc(z.vlan_id_ranges)} | ${z.vlans_count ?? "-"} |`
+  );
+
+  return [
+    `**${records.length} VLAN Zones**`,
+    "",
+    "| ID | Name | Company ID | VLAN ID Ranges | VLANs |",
+    "|---|---|---|---|---|",
+    ...rows,
+  ].join("\n");
+}
+
+export function formatVlanZoneDetail(z: HuduVlanZone): string {
+  return [
+    `# VLAN Zone: ${esc(z.name) || z.id}`,
+    "",
+    "| Field | Value |",
+    "|---|---|",
+    `| ID | ${z.id} |`,
+    `| Name | ${esc(z.name) || "-"} |`,
+    `| Company ID | ${z.company_id} |`,
+    `| VLAN ID Ranges | ${esc(z.vlan_id_ranges) || "-"} |`,
+    `| VLANs count | ${z.vlans_count ?? "-"} |`,
+    `| Hudu URL | ${esc(z.url) || "-"} |`,
+    `| Archived | ${z.archived_at ?? "No"} |`,
+    `| Created | ${z.created_at ?? ""} |`,
+    `| Updated | ${z.updated_at ?? ""} |`,
+    ...(z.description ? ["", "## Description", "", truncate(z.description, 2000)] : []),
+  ].join("\n");
+}
+
+// ---- Flags ----
+
+export function formatFlagList(paged: HuduPagedResponse<HuduFlag>): string {
+  if (paged.records.length === 0) return "No flags found.";
 
   const rows = paged.records.map(
-    (v) => `| ${v.id} | ${v.vid ?? ""} | ${esc(v.name)} | ${truncate(v.description, 60)} |`
+    (f) => `| ${f.id} | ${f.flag_type_id} | ${esc(f.flagable_type)}#${f.flagable_id} | ${truncate(f.description, 60)} | ${f.created_at ?? ""} |`
   );
 
   return [
     pageInfo(paged),
     "",
-    "| ID | VID | Name | Description |",
-    "|---|---|---|---|",
+    "| ID | Flag Type ID | Flagged Record | Description | Created |",
+    "|---|---|---|---|---|",
     ...rows,
   ].join("\n");
+}
+
+export function formatFlagDetail(f: HuduFlag): string {
+  return [
+    `# Flag: ${f.id}`,
+    "",
+    "| Field | Value |",
+    "|---|---|",
+    `| ID | ${f.id} |`,
+    `| Flag Type ID | ${f.flag_type_id} |`,
+    `| Flagged Record | ${esc(f.flagable_type)}#${f.flagable_id} |`,
+    `| Created | ${f.created_at ?? ""} |`,
+    `| Updated | ${f.updated_at ?? ""} |`,
+    ...(f.description ? ["", "## Description", "", truncate(f.description, 2000)] : []),
+  ].join("\n");
+}
+
+// ---- Flag Types ----
+
+export function formatFlagTypeList(paged: HuduPagedResponse<HuduFlagType>): string {
+  if (paged.records.length === 0) return "No flag types found.";
+
+  const rows = paged.records.map(
+    (t) => `| ${t.id} | ${esc(t.name)} | ${esc(t.color)} | ${esc(t.slug)} | ${t.updated_at ?? ""} |`
+  );
+
+  return [
+    pageInfo(paged),
+    "",
+    "| ID | Name | Color | Slug | Updated |",
+    "|---|---|---|---|---|",
+    ...rows,
+  ].join("\n");
+}
+
+export function formatFlagTypeDetail(t: HuduFlagType): string {
+  return [
+    `# Flag Type: ${esc(t.name)}`,
+    "",
+    "| Field | Value |",
+    "|---|---|",
+    `| ID | ${t.id} |`,
+    `| Name | ${esc(t.name)} |`,
+    `| Color | ${esc(t.color)} |`,
+    `| Slug | ${esc(t.slug) || "-"} |`,
+    `| Created | ${t.created_at ?? ""} |`,
+    `| Updated | ${t.updated_at ?? ""} |`,
+  ].join("\n");
+}
+
+// ---- Procedure Tasks ----
+
+export function formatProcedureTaskList(records: HuduProcedureTask[]): string {
+  if (records.length === 0) return "No procedure tasks found.";
+
+  const rows = records.map(
+    (t) => `| ${t.id} | ${esc(t.name)} | ${t.procedure_id} | ${t.position ?? "-"} | ${esc(t.priority) || "-"} | ${t.completed ? "Yes" : "No"} | ${esc(t.formatted_due_date) || "-"} |`
+  );
+
+  return [
+    `**${records.length} procedure tasks**`,
+    "",
+    "| ID | Name | Procedure ID | Position | Priority | Completed | Due |",
+    "|---|---|---|---|---|---|---|",
+    ...rows,
+  ].join("\n");
+}
+
+export function formatProcedureTaskDetail(t: HuduProcedureTask): string {
+  const lines = [
+    `# Procedure Task: ${esc(t.name)}`,
+    "",
+    "| Field | Value |",
+    "|---|---|",
+    `| ID | ${t.id} |`,
+    `| Name | ${esc(t.name)} |`,
+    `| Procedure ID | ${t.procedure_id} |`,
+    `| Position | ${t.position ?? "-"} |`,
+    `| Priority | ${esc(t.priority) || "-"} |`,
+    `| Completed | ${t.completed ? "Yes" : "No"} |`,
+    `| Completed Date | ${esc(t.completed_date) || "-"} |`,
+    `| Due Date | ${esc(t.formatted_due_date) || "-"} |`,
+    `| Completed By | ${esc(t.user_name) || "-"} (ID: ${t.user_id ?? "-"}) |`,
+    `| Assigned (count) | ${t.assigned_users?.length ?? 0} |`,
+    `| First Assigned | ${esc(t.first_assigned_user_name) || "-"} (ID: ${t.first_assigned_user_id ?? "-"}) |`,
+    `| Optional | ${t.optional ? "Yes" : "No"} |`,
+    `| Parent Task ID | ${t.parent_task_id ?? "-"} |`,
+    `| Subtask Count | ${t.subtask_count ?? 0} |`,
+    `| Hudu URL | ${esc(t.url) || "-"} |`,
+    `| Created | ${t.created_at ?? ""} |`,
+    `| Updated | ${t.updated_at ?? ""} |`,
+  ];
+
+  if (t.description) {
+    lines.push("", "## Description", "", truncate(t.description, 3000));
+  }
+  if (t.completion_notes) {
+    lines.push("", "## Completion Notes", "", truncate(t.completion_notes, 2000));
+  }
+
+  return lines.join("\n");
 }
 
 // ---- Network / IP detail ----

--- a/src/schemas/inputs.ts
+++ b/src/schemas/inputs.ts
@@ -62,6 +62,7 @@ export const listArticlesSchema = z.object({
   name: z.string().optional().describe("Filter articles by exact name. For partial lookups, use 'search' instead."),
   company_id: z.coerce.number().int().positive().optional().describe("Filter by company ID. Omit for global KB articles."),
   draft: z.boolean().optional().describe("Filter by draft status (true = drafts only, false = published only)"),
+  enable_sharing: z.boolean().optional().describe("Filter by public-sharing status (true = articles with a public share URL)"),
   slug: z.string().optional().describe("Filter by URL slug"),
   updated_at: z.string().optional().describe("Filter articles updated within a range or at an exact time (ISO format)"),
   page: z.coerce.number().min(1).default(1).describe("Page number (default 1)"),
@@ -100,13 +101,21 @@ export const getWebsiteSchema = z.object({
 });
 
 // ---- Procedures (Processes in the Hudu UI) ----
+// Hudu calls templates "processes" and active instances "runs". The list
+// endpoint returns both; use `type` to filter.
 
 export const listProceduresSchema = z.object({
-  name: z.string().optional().describe("Filter procedures by name"),
+  name: z.string().optional().describe("Filter procedures by name (exact match, case-insensitive)"),
   company_id: z.coerce.number().int().positive().optional().describe("Filter by company ID"),
   slug: z.string().optional().describe("Filter by URL slug"),
-  global_template: z.enum(["true", "false"]).optional().describe("Filter for global templates ('true') vs company-specific procedures ('false')"),
-  parent_procedure_id: z.coerce.number().int().positive().optional().describe("Filter for child procedures of a specific parent procedure"),
+  type: z.enum(["process", "run", "all"]).optional().describe("Filter by type: 'process' (templates), 'run' (active instances), or 'all' (both, default)"),
+  process_scope: z.enum(["global", "company"]).optional().describe("Filter processes by scope: 'global' (available to all companies) or 'company' (company-specific)"),
+  parent_process_id: z.coerce.number().int().positive().optional().describe("Filter runs by parent process ID (the process they were kicked off from)"),
+  parent_procedure_id: z.coerce.number().int().positive().optional().describe("DEPRECATED alias for parent_process_id. Prefer parent_process_id."),
+  global_template: z.enum(["true", "false"]).optional().describe("DEPRECATED. Use process_scope instead."),
+  archived: z.enum(["true", "false", "1", "0"]).optional().describe("Filter by archived status. Defaults to non-archived only if omitted."),
+  created_at: z.string().optional().describe("Filter by creation date (ISO format, or 'start,end' range)"),
+  updated_at: z.string().optional().describe("Filter by update date (ISO format, or 'start,end' range)"),
   page: z.coerce.number().min(1).default(1).describe("Page number (default 1)"),
   page_size: z.coerce.number().min(1).max(1000).optional().describe("Number of results per page (default 25)"),
 });
@@ -129,10 +138,13 @@ export const listActivityLogsSchema = z.object({
 });
 
 // ---- Folders ----
+// Folders are typed: 'article' (KB folders) or 'photo' (photo folders).
 
 export const listFoldersSchema = z.object({
   name: z.string().optional().describe("Filter folders by name"),
   company_id: z.coerce.number().int().positive().optional().describe("Filter folders by company ID"),
+  in_company: z.boolean().optional().describe("When true, returns only company-specific folders"),
+  folder_type: z.enum(["article", "photo"]).optional().describe("Filter by folder type: 'article' (KB folders) or 'photo' (photo folders)"),
   page: z.coerce.number().min(1).default(1).describe("Page number (default 1)"),
   page_size: z.coerce.number().min(1).max(1000).optional().describe("Number of results per page (default 25)"),
 });
@@ -140,11 +152,23 @@ export const listFoldersSchema = z.object({
 // ---- Users and Groups ----
 
 export const listUsersSchema = z.object({
-  page: z.coerce.number().min(1).default(1).describe("Page number (25 results per page, default 1)"),
+  first_name: z.string().optional().describe("Filter users by first name"),
+  last_name: z.string().optional().describe("Filter users by last name"),
+  search: z.string().optional().describe("Search across first and last name (fuzzy match)"),
+  email: z.string().optional().describe("Filter users by email address"),
+  security_level: z.enum(["super_admin", "admin", "spectator", "editor", "author", "portal_member", "portal_admin"]).optional().describe("Filter by security level"),
+  portal_member_company_id: z.coerce.number().int().positive().optional().describe("Filter portal members by their associated company ID"),
+  archived: z.boolean().optional().describe("Filter by archived status"),
+  page: z.coerce.number().min(1).default(1).describe("Page number (default 1)"),
+  page_size: z.coerce.number().min(1).max(1000).optional().describe("Number of results per page (default 25)"),
 });
 
 export const listGroupsSchema = z.object({
-  page: z.coerce.number().min(1).default(1).describe("Page number (25 results per page, default 1)"),
+  name: z.string().optional().describe("Filter groups by name (case-insensitive)"),
+  default: z.boolean().optional().describe("Filter by default-group status"),
+  search: z.string().optional().describe("Search across group names"),
+  page: z.coerce.number().min(1).default(1).describe("Page number (default 1)"),
+  page_size: z.coerce.number().min(1).max(1000).optional().describe("Number of results per page (default 25)"),
 });
 
 // ---- Relations ----
@@ -177,15 +201,83 @@ export const getIpAddressSchema = z.object({
   ip_address_id: z.coerce.number().int().positive().describe("The ID of the IP address record to retrieve"),
 });
 
+// ---- VLANs ----
+// /vlans returns ALL records in one response (no pagination).
+
 export const listVlansSchema = z.object({
   company_id: z.coerce.number().int().positive().optional().describe("Filter VLANs by company ID"),
-  page: z.coerce.number().min(1).default(1).describe("Page number (25 results per page, default 1)"),
+  vlan_zone_id: z.coerce.number().int().positive().optional().describe("Filter VLANs by VLAN Zone ID"),
+  name: z.string().optional().describe("Filter by VLAN name (exact match)"),
+  vlan_id: z.coerce.number().int().positive().optional().describe("Filter by numeric VLAN ID (1-4094)"),
+  archived: z.boolean().optional().describe("Filter by archive status (default: non-archived only)"),
+});
+
+export const getVlanSchema = z.object({
+  vlan_id: z.coerce.number().int().positive().describe("The ID of the VLAN record to retrieve"),
+});
+
+// ---- VLAN Zones ----
+
+export const listVlanZonesSchema = z.object({
+  company_id: z.coerce.number().int().positive().optional().describe("Filter by company ID"),
+  name: z.string().optional().describe("Filter by zone name (exact match)"),
+  archived: z.boolean().optional().describe("Filter by archive status (default: non-archived only)"),
+});
+
+export const getVlanZoneSchema = z.object({
+  vlan_zone_id: z.coerce.number().int().positive().describe("The ID of the VLAN Zone to retrieve"),
+});
+
+// ---- Flags and Flag Types ----
+
+export const listFlagsSchema = z.object({
+  flag_type_id: z.coerce.number().int().positive().optional().describe("Filter by flag type ID"),
+  flagable_type: z.enum(["Asset", "Website", "Article", "AssetPassword", "Company", "Procedure", "RackStorage", "Network", "IpAddress", "Vlan", "VlanZone"]).optional().describe("Filter by record type that the flag is attached to"),
+  flagable_id: z.coerce.number().int().positive().optional().describe("Filter by record ID (pair with flagable_type)"),
+  description: z.string().optional().describe("Filter by flag description"),
+  created_at: z.string().optional().describe("Filter by creation date (ISO format)"),
+  updated_at: z.string().optional().describe("Filter by update date (ISO format)"),
+  page: z.coerce.number().min(1).default(1).describe("Page number (default 1)"),
+  page_size: z.coerce.number().min(1).max(1000).optional().describe("Number of results per page (default 25)"),
+});
+
+export const getFlagSchema = z.object({
+  flag_id: z.coerce.number().int().positive().describe("The ID of the flag to retrieve"),
+});
+
+export const listFlagTypesSchema = z.object({
+  name: z.string().optional().describe("Filter by exact flag type name"),
+  color: z.string().optional().describe("Filter by color value"),
+  slug: z.string().optional().describe("Filter by slug"),
+  created_at: z.string().optional().describe("Filter by creation date (ISO format)"),
+  updated_at: z.string().optional().describe("Filter by update date (ISO format)"),
+  page: z.coerce.number().min(1).default(1).describe("Page number (default 1)"),
+  page_size: z.coerce.number().min(1).max(1000).optional().describe("Number of results per page (default 25)"),
+});
+
+export const getFlagTypeSchema = z.object({
+  flag_type_id: z.coerce.number().int().positive().describe("The ID of the flag type to retrieve"),
+});
+
+// ---- Procedure Tasks ----
+// Individual tasks within a Process (template) or Run (active instance).
+// `procedure_id` filters by either parent process or parent run.
+
+export const listProcedureTasksSchema = z.object({
+  procedure_id: z.coerce.number().int().positive().optional().describe("Filter by process or run ID (returns all tasks for that process/run)"),
+  name: z.string().optional().describe("Filter by task name"),
+  company_id: z.coerce.number().int().positive().optional().describe("Filter by company ID"),
+});
+
+export const getProcedureTaskSchema = z.object({
+  procedure_task_id: z.coerce.number().int().positive().describe("The ID of the procedure task to retrieve"),
 });
 
 // ---- Lists (Admin > Lists; source for ListSelect layout fields) ----
 
 export const listListsSchema = z.object({
-  name: z.string().optional().describe("Filter lists by name"),
+  query: z.string().optional().describe("Search lists by name (partial match)"),
+  name: z.string().optional().describe("Filter by exact list name"),
   page: z.coerce.number().min(1).default(1).describe("Page number (default 1)"),
   page_size: z.coerce.number().min(1).max(1000).optional().describe("Number of results per page (default 25)"),
 });

--- a/src/tools/articles.ts
+++ b/src/tools/articles.ts
@@ -27,6 +27,7 @@ export function register(server: McpServer, env: Env) {
             name: args.name,
             company_id: args.company_id,
             draft: args.draft,
+            enable_sharing: args.enable_sharing,
             slug: args.slug,
             updated_at: args.updated_at,
             page_size: args.page_size,

--- a/src/tools/flags.ts
+++ b/src/tools/flags.ts
@@ -1,0 +1,149 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  listFlagsSchema,
+  getFlagSchema,
+  listFlagTypesSchema,
+  getFlagTypeSchema,
+} from "../schemas/inputs";
+import { huduFetch, huduFetchPaged } from "../api-client";
+import {
+  formatFlagList,
+  formatFlagDetail,
+  formatFlagTypeList,
+  formatFlagTypeDetail,
+} from "../formatters/markdown";
+import type { HuduFlag, HuduFlagType } from "../types";
+
+export function register(server: McpServer, env: Env) {
+  server.registerTool(
+    "hudu_list_flags",
+    {
+      description:
+        "List flags attached to Hudu records. Flagable types: Asset, Website, Article, AssetPassword, Company, Procedure, RackStorage, Network, IpAddress, Vlan, VlanZone. Use flag_type_id to filter by a specific flag category (see hudu_list_flag_types).",
+      inputSchema: listFlagsSchema,
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        openWorldHint: true,
+      },
+    },
+    async (args) => {
+      try {
+        const data = await huduFetchPaged<HuduFlag>(
+          env,
+          "flags",
+          {
+            flag_type_id: args.flag_type_id,
+            flagable_type: args.flagable_type,
+            flagable_id: args.flagable_id,
+            description: args.description,
+            created_at: args.created_at,
+            updated_at: args.updated_at,
+            page_size: args.page_size,
+          },
+          args.page
+        );
+
+        return {
+          content: [{ type: "text" as const, text: formatFlagList(data) }],
+        };
+      } catch (err) {
+        console.error("[hudu_list_flags]", err instanceof Error ? err.message : String(err));
+        throw err;
+      }
+    }
+  );
+
+  server.registerTool(
+    "hudu_get_flag",
+    {
+      description: "Get a specific Hudu flag by ID, including the record it's attached to and its description.",
+      inputSchema: getFlagSchema,
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        openWorldHint: true,
+      },
+    },
+    async (args) => {
+      try {
+        const raw = await huduFetch<{ flag: HuduFlag }>(env, `flags/${args.flag_id}`);
+        const flag = raw.flag ?? (raw as unknown as HuduFlag);
+
+        return {
+          content: [{ type: "text" as const, text: formatFlagDetail(flag) }],
+        };
+      } catch (err) {
+        console.error("[hudu_get_flag]", err instanceof Error ? err.message : String(err));
+        throw err;
+      }
+    }
+  );
+
+  server.registerTool(
+    "hudu_list_flag_types",
+    {
+      description:
+        "List the configured flag categories (e.g. 'Inactive', 'Managed', 'Needs Review'). Each flag type has a name, color, and slug. Use this to discover available flag categories before filtering hudu_list_flags by flag_type_id.",
+      inputSchema: listFlagTypesSchema,
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        openWorldHint: true,
+      },
+    },
+    async (args) => {
+      try {
+        const data = await huduFetchPaged<HuduFlagType>(
+          env,
+          "flag_types",
+          {
+            name: args.name,
+            color: args.color,
+            slug: args.slug,
+            created_at: args.created_at,
+            updated_at: args.updated_at,
+            page_size: args.page_size,
+          },
+          args.page
+        );
+
+        return {
+          content: [{ type: "text" as const, text: formatFlagTypeList(data) }],
+        };
+      } catch (err) {
+        console.error("[hudu_list_flag_types]", err instanceof Error ? err.message : String(err));
+        throw err;
+      }
+    }
+  );
+
+  server.registerTool(
+    "hudu_get_flag_type",
+    {
+      description: "Get a specific Hudu flag type (category) by ID, including its display color.",
+      inputSchema: getFlagTypeSchema,
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        openWorldHint: true,
+      },
+    },
+    async (args) => {
+      try {
+        const raw = await huduFetch<{ flag_type: HuduFlagType }>(
+          env,
+          `flag_types/${args.flag_type_id}`
+        );
+        const flagType = raw.flag_type ?? (raw as unknown as HuduFlagType);
+
+        return {
+          content: [{ type: "text" as const, text: formatFlagTypeDetail(flagType) }],
+        };
+      } catch (err) {
+        console.error("[hudu_get_flag_type]", err instanceof Error ? err.message : String(err));
+        throw err;
+      }
+    }
+  );
+}

--- a/src/tools/folders.ts
+++ b/src/tools/folders.ts
@@ -9,7 +9,7 @@ export function register(server: McpServer, env: Env) {
     "hudu_list_folders",
     {
       description:
-        "List folders in Hudu. Filter by company_id. Folders organize Knowledge Base articles and other content. Returns 25 per page.",
+        "List folders in Hudu. Folders are typed: 'article' (Knowledge Base folders) or 'photo' (photo folders). Filter by company_id, name, folder_type, or in_company. Returns 25 per page.",
       inputSchema: listFoldersSchema,
       annotations: {
         readOnlyHint: true,
@@ -25,6 +25,8 @@ export function register(server: McpServer, env: Env) {
           {
             name: args.name,
             company_id: args.company_id,
+            in_company: args.in_company,
+            folder_type: args.folder_type,
             page_size: args.page_size,
           },
           args.page

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -15,6 +15,9 @@ import { register as registerLists } from "./lists";
 import { register as registerNetworks } from "./networks";
 import { register as registerPasswordFolders } from "./password-folders";
 import { register as registerIntegrations } from "./integrations";
+import { register as registerFlags } from "./flags";
+import { register as registerVlans } from "./vlans";
+import { register as registerProcedureTasks } from "./procedure-tasks";
 
 export function registerAllTools(server: McpServer, env: Env) {
   // Phase 1: Read-only tools for QBR automation and cross-reference
@@ -39,6 +42,13 @@ export function registerAllTools(server: McpServer, env: Env) {
   registerNetworks(server, env);
   registerPasswordFolders(server, env);
   registerIntegrations(server, env);
+
+  // Phase 1.6: Flags, VLANs (+ Zones), Procedure Tasks. Sourced from the
+  // canonical Hudu swagger (2.41.2). See PR description for filter-enhancement
+  // changes to folders, procedures, users, groups, articles, lists.
+  registerFlags(server, env);
+  registerVlans(server, env);
+  registerProcedureTasks(server, env);
 
   // Phase 2: Write tools (create/update assets & articles, magic dash writes on local-dev)
 }

--- a/src/tools/lists.ts
+++ b/src/tools/lists.ts
@@ -9,7 +9,7 @@ export function register(server: McpServer, env: Env) {
     "hudu_list_lists",
     {
       description:
-        "List Hudu Admin > Lists. These provide the option sets for ListSelect layout fields. Use this to verify a list exists before referencing it from a layout (e.g. before the Dropdown -> ListSelect migration).",
+        "List Hudu Admin > Lists. These provide the option sets for ListSelect layout fields. Use 'query' for partial-match search, 'name' for exact match. Use this to verify a list exists before referencing it from a layout (e.g. before the Dropdown -> ListSelect migration).",
       inputSchema: listListsSchema,
       annotations: {
         readOnlyHint: true,
@@ -23,6 +23,7 @@ export function register(server: McpServer, env: Env) {
           env,
           "lists",
           {
+            query: args.query,
             name: args.name,
             page_size: args.page_size,
           },

--- a/src/tools/procedure-tasks.ts
+++ b/src/tools/procedure-tasks.ts
@@ -1,0 +1,84 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { listProcedureTasksSchema, getProcedureTaskSchema } from "../schemas/inputs";
+import { huduFetch } from "../api-client";
+import {
+  formatProcedureTaskList,
+  formatProcedureTaskDetail,
+} from "../formatters/markdown";
+import type { HuduProcedureTask } from "../types";
+
+export function register(server: McpServer, env: Env) {
+  server.registerTool(
+    "hudu_list_procedure_tasks",
+    {
+      description:
+        "List the individual tasks within a Hudu Process (template) or Run (active instance). Filter by procedure_id to see all tasks for one process/run, by name, or by company_id. Useful for tracking step-level completion in onboarding/offboarding workflows. Returns all matching tasks in one response.",
+      inputSchema: listProcedureTasksSchema,
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        openWorldHint: true,
+      },
+    },
+    async (args) => {
+      try {
+        const raw = await huduFetch<{ procedure_tasks: HuduProcedureTask[] } | HuduProcedureTask[]>(
+          env,
+          "procedure_tasks",
+          {
+            procedure_id: args.procedure_id,
+            name: args.name,
+            company_id: args.company_id,
+          }
+        );
+
+        const records = Array.isArray(raw)
+          ? raw
+          : raw.procedure_tasks ?? [];
+
+        return {
+          content: [{ type: "text" as const, text: formatProcedureTaskList(records) }],
+        };
+      } catch (err) {
+        console.error(
+          "[hudu_list_procedure_tasks]",
+          err instanceof Error ? err.message : String(err)
+        );
+        throw err;
+      }
+    }
+  );
+
+  server.registerTool(
+    "hudu_get_procedure_task",
+    {
+      description:
+        "Get a specific procedure task by ID, including completion status, assigned users, due date, and any subtask references.",
+      inputSchema: getProcedureTaskSchema,
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        openWorldHint: true,
+      },
+    },
+    async (args) => {
+      try {
+        const raw = await huduFetch<{ procedure_task: HuduProcedureTask }>(
+          env,
+          `procedure_tasks/${args.procedure_task_id}`
+        );
+        const task = raw.procedure_task ?? (raw as unknown as HuduProcedureTask);
+
+        return {
+          content: [{ type: "text" as const, text: formatProcedureTaskDetail(task) }],
+        };
+      } catch (err) {
+        console.error(
+          "[hudu_get_procedure_task]",
+          err instanceof Error ? err.message : String(err)
+        );
+        throw err;
+      }
+    }
+  );
+}

--- a/src/tools/procedures.ts
+++ b/src/tools/procedures.ts
@@ -9,7 +9,7 @@ export function register(server: McpServer, env: Env) {
     "hudu_list_procedures",
     {
       description:
-        "List procedures in Hudu. In the Hudu UI these are called 'Processes'. Filter by name or company_id. Returns 25 per page.",
+        "List procedures in Hudu. The API returns both 'processes' (templates) and 'runs' (active instances created via kickoff). Use type='process'/'run'/'all', process_scope='global'/'company' for scope. parent_process_id filters runs by parent process. Returns 25 per page. (In the Hudu UI 'procedure' = 'Process'.)",
       inputSchema: listProceduresSchema,
       annotations: {
         readOnlyHint: true,
@@ -26,8 +26,13 @@ export function register(server: McpServer, env: Env) {
             name: args.name,
             company_id: args.company_id,
             slug: args.slug,
+            type: args.type,
+            process_scope: args.process_scope,
+            parent_process_id: args.parent_process_id ?? args.parent_procedure_id,
             global_template: args.global_template,
-            parent_procedure_id: args.parent_procedure_id,
+            archived: args.archived,
+            created_at: args.created_at,
+            updated_at: args.updated_at,
             page_size: args.page_size,
           },
           args.page

--- a/src/tools/users-groups.ts
+++ b/src/tools/users-groups.ts
@@ -9,7 +9,7 @@ export function register(server: McpServer, env: Env) {
     "hudu_list_users",
     {
       description:
-        "List Hudu users (people with access to the Hudu instance). Returns 25 per page.",
+        "List Hudu users. Filter by first_name/last_name, search (across name), email, security_level ('super_admin', 'admin', 'spectator', 'editor', 'author', 'portal_member', 'portal_admin'), portal_member_company_id, or archived status. Returns 25 per page.",
       inputSchema: listUsersSchema,
       annotations: {
         readOnlyHint: true,
@@ -22,7 +22,16 @@ export function register(server: McpServer, env: Env) {
         const data = await huduFetchPaged<HuduUser>(
           env,
           "users",
-          {},
+          {
+            first_name: args.first_name,
+            last_name: args.last_name,
+            search: args.search,
+            email: args.email,
+            security_level: args.security_level,
+            portal_member_company_id: args.portal_member_company_id,
+            archived: args.archived,
+            page_size: args.page_size,
+          },
           args.page
         );
 
@@ -40,7 +49,7 @@ export function register(server: McpServer, env: Env) {
     "hudu_list_groups",
     {
       description:
-        "List groups in Hudu. Groups organize users for access control and permissions. Returns 25 per page.",
+        "List groups in Hudu. Groups organize users for access control and permissions. Filter by name, default-group status, or search across names. Returns 25 per page.",
       inputSchema: listGroupsSchema,
       annotations: {
         readOnlyHint: true,
@@ -53,7 +62,12 @@ export function register(server: McpServer, env: Env) {
         const data = await huduFetchPaged<HuduGroup>(
           env,
           "groups",
-          {},
+          {
+            name: args.name,
+            default: args.default,
+            search: args.search,
+            page_size: args.page_size,
+          },
           args.page
         );
 

--- a/src/tools/vlans.ts
+++ b/src/tools/vlans.ts
@@ -1,0 +1,139 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  listVlansSchema,
+  getVlanSchema,
+  listVlanZonesSchema,
+  getVlanZoneSchema,
+} from "../schemas/inputs";
+import { huduFetch } from "../api-client";
+import {
+  formatVlanList,
+  formatVlanDetail,
+  formatVlanZoneList,
+  formatVlanZoneDetail,
+} from "../formatters/markdown";
+import type { HuduVlan, HuduVlanZone } from "../types";
+
+export function register(server: McpServer, env: Env) {
+  server.registerTool(
+    "hudu_list_vlans",
+    {
+      description:
+        "List Hudu VLANs. Filter by company_id, vlan_zone_id, exact name, or numeric vlan_id (1-4094). Returns all matching VLANs in one response (this endpoint does not paginate). Pairs with hudu_list_networks for full IPAM coverage.",
+      inputSchema: listVlansSchema,
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        openWorldHint: true,
+      },
+    },
+    async (args) => {
+      try {
+        const records = await huduFetch<HuduVlan[]>(env, "vlans", {
+          company_id: args.company_id,
+          vlan_zone_id: args.vlan_zone_id,
+          name: args.name,
+          vlan_id: args.vlan_id,
+          archived: args.archived,
+        });
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: formatVlanList(Array.isArray(records) ? records : []),
+            },
+          ],
+        };
+      } catch (err) {
+        console.error("[hudu_list_vlans]", err instanceof Error ? err.message : String(err));
+        throw err;
+      }
+    }
+  );
+
+  server.registerTool(
+    "hudu_get_vlan",
+    {
+      description: "Get a specific Hudu VLAN by ID, including its numeric VLAN tag, zone, and status/role list-item references.",
+      inputSchema: getVlanSchema,
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        openWorldHint: true,
+      },
+    },
+    async (args) => {
+      try {
+        const vlan = await huduFetch<HuduVlan>(env, `vlans/${args.vlan_id}`);
+
+        return {
+          content: [{ type: "text" as const, text: formatVlanDetail(vlan) }],
+        };
+      } catch (err) {
+        console.error("[hudu_get_vlan]", err instanceof Error ? err.message : String(err));
+        throw err;
+      }
+    }
+  );
+
+  server.registerTool(
+    "hudu_list_vlan_zones",
+    {
+      description:
+        "List VLAN Zones (logical groupings of VLANs, e.g. by datacenter or building). Filter by company_id or name. Returns all matching zones in one response (no pagination).",
+      inputSchema: listVlanZonesSchema,
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        openWorldHint: true,
+      },
+    },
+    async (args) => {
+      try {
+        const records = await huduFetch<HuduVlanZone[]>(env, "vlan_zones", {
+          company_id: args.company_id,
+          name: args.name,
+          archived: args.archived,
+        });
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: formatVlanZoneList(Array.isArray(records) ? records : []),
+            },
+          ],
+        };
+      } catch (err) {
+        console.error("[hudu_list_vlan_zones]", err instanceof Error ? err.message : String(err));
+        throw err;
+      }
+    }
+  );
+
+  server.registerTool(
+    "hudu_get_vlan_zone",
+    {
+      description: "Get a specific VLAN Zone by ID, including its VLAN ID ranges and assigned VLAN count.",
+      inputSchema: getVlanZoneSchema,
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        openWorldHint: true,
+      },
+    },
+    async (args) => {
+      try {
+        const zone = await huduFetch<HuduVlanZone>(env, `vlan_zones/${args.vlan_zone_id}`);
+
+        return {
+          content: [{ type: "text" as const, text: formatVlanZoneDetail(zone) }],
+        };
+      } catch (err) {
+        console.error("[hudu_get_vlan_zone]", err instanceof Error ? err.message : String(err));
+        throw err;
+      }
+    }
+  );
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -350,13 +350,95 @@ export interface HuduIpAddress {
 }
 
 // ---- VLANs ----
+// Verified shape from GET /vlans/:id (2026-05-13). Field is `vlan_id` (numeric
+// 1-4094), not `vid`. Endpoint returns bare array; does not paginate.
 
 export interface HuduVlan {
   id: number;
-  company_id: number;
   name: string | null;
-  vid: number | null;
+  slug: string | null;
+  vlan_id: number | null;
   description: string | null;
+  notes: string | null;
+  company_id: number;
+  vlan_zone_id: number | null;
+  status_list_item_id: number | null;
+  role_list_item_id: number | null;
+  networks_count: number | null;
+  url: string | null;
+  archived_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+// ---- VLAN Zones ----
+// Logical grouping of VLANs (datacenter, building). vlan_id_ranges is a string
+// like "100-500,1000-1500".
+
+export interface HuduVlanZone {
+  id: number;
+  name: string | null;
+  slug: string | null;
+  description: string | null;
+  vlan_id_ranges: string | null;
+  company_id: number;
+  vlans_count: number | null;
+  url: string | null;
+  archived_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+// ---- Flags ----
+// Lightweight labels attached to any record. flagable_type is one of: Asset,
+// Website, Article, AssetPassword, Company, Procedure, RackStorage, Network,
+// IpAddress, Vlan, VlanZone.
+
+export interface HuduFlag {
+  id: number;
+  flag_type_id: number;
+  description: string | null;
+  flagable_type: string;
+  flagable_id: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface HuduFlagType {
+  id: number;
+  name: string;
+  color: string;
+  slug: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+// ---- Procedure Tasks ----
+// Individual tasks within a Process (template) or Run (active instance).
+
+export interface HuduProcedureTask {
+  id: number;
+  name: string;
+  description: string | null;
+  position: number | null;
+  priority: string | null;
+  completed: boolean | null;
+  completed_date: string | null;
+  completion_notes: string | null;
+  due_date: string | null;
+  formatted_due_date: string | null;
+  user_id: number | null;
+  user_name: string | null;
+  assigned_users: number[] | null;
+  first_assigned_user_id: number | null;
+  first_assigned_user_name: string | null;
+  procedure_id: number;
+  optional: boolean | null;
+  parent_task_id: number | null;
+  subtask_ids: number[] | null;
+  subtask_count: number | null;
+  has_subtasks: boolean | null;
+  url: string | null;
   created_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
**Stacked on #64.** Merge that one first; GitHub will auto-rebase this onto main.

## Summary
Sourced from the canonical Hudu swagger (2.41.2) the user pasted. 10 new read-only MCP tools across 4 resource families, plus filter enhancements to 6 existing tools.

- **New tools (10):** flags (list/get), flag_types (list/get), vlans (list/get), vlan_zones (list/get), procedure_tasks (list/get). Total tool count **28 → 38**.
- **Filter enhancements (6):** folders (folder_type, in_company), procedures (type/process_scope/archived/dates + parent_process_id rename), users (7 new filters), groups (3 new filters), articles (enable_sharing), lists (query for partial match).
- **Type corrections:** `HuduVlan.vid` → `vlan_id` plus 8 missing fields the swagger declares.

## Verification
9/9 endpoints return 200 (smoke-tested via curl against docs.networkzit.com with the real API key):

| Endpoint | Status |
|---|---|
| GET /flags | 200 |
| GET /flags/237 | 200 |
| GET /flag_types | 200 |
| GET /flag_types/1 | 200 |
| GET /vlans | 200 |
| GET /vlans/1 | 200 |
| GET /vlan_zones | 200 (empty array — not configured yet at NIT) |
| GET /procedure_tasks?procedure_id=1 | 200 |
| GET /procedure_tasks/28 | 200 |

`npm run typecheck` clean. `npm run build` clean.

## Why these were chosen
- **Flags + flag_types** — directly addresses your audit's "Flags. Likely not standardized. Seven flag types recommended" finding. You can now read existing flags and discover the configured categories before reorganizing.
- **VLANs + VLAN Zones** — completes the IPAM picture started in Phase 1.5 (networks + ip_addresses). VLAN Zones are empty at NIT today; the endpoint is wired for when you start using them.
- **Procedure Tasks** — drill into the individual steps inside a Process/Run. Procedures already showed aggregate completion; this exposes which specific step is stuck.
- **Filter enhancements** — folders are now **typed** (`article` vs `photo` folders). Without `folder_type`, KB searches mix in photo folders. Procedures filter naming is broken in the swagger (parent_procedure_id is deprecated); aliased for back-compat.

## What was NOT added (and why)
- **rack_storages** — swagger lists it but NIT's instance returns 500. Hudu-side bug. Defer.
- **asset_passwords** — 401 with current key scope (no password access). Provision a separate scoped key to unlock.
- **exports** — 401, scope-gated.
- **matchers** — works but requires `integration_id` query param. Skipped until we have an integration ID to test against.
- **photos / public_photos** — work, but no immediate use case. Defer until you have one.
- **Detail endpoints for users/groups/folders/uploads/relations** — list responses already include the full record; detail endpoints would be redundant.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run build` clean
- [x] Curl smoke test: 9/9 endpoints return 200
- [ ] Manually verify a flag-type-id filter (e.g. `hudu_list_flags?flag_type_id=1`)
- [ ] Manually verify procedure_id filter on procedure_tasks
- [ ] `npm run dev` and exercise one tool from each new family through your MCP client
- [ ] Deploy via `npm run deploy` and verify on hudu-mcp.networkzit.com after #64 merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)